### PR TITLE
Fix #140 - Reset PR status to "In Review" on any PR comment

### DIFF
--- a/dolt/models.py
+++ b/dolt/models.py
@@ -428,8 +428,8 @@ class PullRequest(BaseModel):
             return "open"
 
         # get the most recent review that approved or blocked
-        decision = pr_reviews.exclude(state=PullRequestReview.COMMENTED).order_by("-reviewed_at").first()
-        if not decision:
+        decision = pr_reviews.order_by("-reviewed_at").first()
+        if not decision or (decision and decision.state == PullRequestReview.COMMENTED):
             # all PRs are "comments"
             return "in-review"
         if decision.state == PullRequestReview.APPROVED:


### PR DESCRIPTION
This updates `PullRequest.status` to return `in-review` on new PR review comments. Currently untested, because my local dev. environment is hosed. Just wanted to get this out for preliminary review for correctness.