### PR TITLE
Add Secrets and SecretsGroup as versioned models, fix user/email handling

### DIFF
--- a/dolt/__init__.py
+++ b/dolt/__init__.py
@@ -123,6 +123,8 @@ __VERSIONED_MODEL_REGISTRY___ = {
         "objectchange": True,
         "relationship": True,
         "relationshipassociation": True,
+        "secret": True,
+        "secretsgroup": True,
         "status": True,
         "tag": True,
         "taggeditem": True,

--- a/dolt/diffs.py
+++ b/dolt/diffs.py
@@ -5,8 +5,9 @@ from django.db import connection
 from django.db import models
 from django.db.models.expressions import RawSQL
 
-from nautobot.dcim.tables import cables, devices, devicetypes, power, racks, sites
 from nautobot.circuits import tables as circuits_tables
+from nautobot.dcim.tables import cables, devices, devicetypes, power, racks, sites
+from nautobot.extras import tables as extras_tables
 from nautobot.ipam import tables as ipam_tables
 from nautobot.tenancy import tables as tenancy_tables
 from nautobot.virtualization import tables as virtualization_tables
@@ -140,6 +141,12 @@ def json_diff_fields(tbl_name):
 
 register_diff_tables(
     {
+        "circuits": {
+            "circuit": circuits_tables.CircuitTable,
+            # "circuittermination": None,
+            "circuittype": circuits_tables.CircuitTypeTable,
+            "provider": circuits_tables.ProviderTable,
+        },
         "dcim": {
             # "baseinterface": devices.BaseInterfaceTable,
             "cable": cables.CableTable,
@@ -190,11 +197,9 @@ register_diff_tables(
             "site": sites.SiteTable,
             "virtualchassis": devices.VirtualChassisTable,
         },
-        "circuits": {
-            "circuit": circuits_tables.CircuitTable,
-            # "circuittermination": None,
-            "circuittype": circuits_tables.CircuitTypeTable,
-            "provider": circuits_tables.ProviderTable,
+        "extras": {
+            "secret": extras_tables.SecretTable,
+            "secretsgroup": extras_tables.SecretsGroupTable,
         },
         "ipam": {
             "aggregate": ipam_tables.AggregateTable,

--- a/dolt/utils.py
+++ b/dolt/utils.py
@@ -15,12 +15,18 @@ class DoltError(Exception):
     pass  # pylint: disable=W0107
 
 
-def author_from_user(usr):
-    """author_from_user returns an author string from a user object."""
-    if usr and usr.username and usr.email:
-        return f"{usr.username} <{usr.email}>"
+def author_from_user(user):
+    """author_from_user returns an author string from a user object.
+
+    Note that while user.email is optional in Django, it's mandatory for Dolt.
+    """
+    if user:
+        if user.email:
+            return f"{user.username} <{user.email}>"
+        # RFC 6761 defines .invalid as a reserved TLD that will never be used for real-world domains
+        return f"{user.username} <{user.username}@nautobot.invalid>"
     # default to generic user
-    return "nautobot <nautobot@ntc.com>"
+    return "unknown <unknown@nautobot.invalid>"
 
 
 def is_dolt_model(model):


### PR DESCRIPTION
- Fix #154 - if a user doesn't have an email address on record, use a dummy email address but keep the username for tracking. Also change the dummy email that's used in the case where there's no user at all since "nautobot@ntc.com" is potentially a real e-mail address.
- Towards #131, add Secret and SecretsGroup as versionable models.