### PR TITLE
Use Nautobot 1.2 plugin banner API for current branch info instead of middleware

### DIFF
--- a/dolt/banner.py
+++ b/dolt/banner.py
@@ -1,0 +1,42 @@
+"""Injection of branch information banner via the Plugins API."""
+
+from django.utils.html import format_html
+
+from nautobot.extras.choices import BannerClassChoices
+from nautobot.extras.plugins import PluginBanner
+
+from dolt.constants import DOLT_BRANCH_KEYWORD
+from dolt.utils import active_branch
+
+
+def banner(context, *args, **kwargs):
+    """Show a banner indicating the current active branch, if the user is logged in."""
+    if not context.request.user.is_authenticated:
+        return None
+    branch_name = active_branch()
+    return PluginBanner(
+        content=format_html(
+            """
+<div class="text-center">
+    Active Branch: <strong>{}</strong>
+    <div class = "pull-right">
+        <div class="btn btn-xs btn-primary" id="branch-share-button">
+            Share
+        </div>
+    </div>
+</div>
+<script>
+    const btn = document.getElementById("branch-share-button");
+    btn.addEventListener('click', ()=>{{
+        const currLink = window.location.href;
+        const copiedLink = currLink + "?{}={}";
+        navigator.clipboard.writeText(copiedLink);
+        btn.textContent = "Copied!"
+    }});
+</script>""",
+            branch_name,
+            DOLT_BRANCH_KEYWORD,
+            branch_name,
+        ),
+        banner_class=BannerClassChoices.CLASS_INFO,
+    )


### PR DESCRIPTION
Now that we have a `banner()` API for plugins, use it to inject the "Active Branch" banner instead of doing so via middleware + the `messages` API. This should solve the cascading-messages issue described in #139.

Note that the Dolt middleware can still potentially inject messages in the case of various branch-related errors, but this should not be an issue during normal operation.

![image](https://user-images.githubusercontent.com/5603551/145443604-dc01e9cb-0c84-4420-925f-06f7949e7c52.png)
